### PR TITLE
added missing line breaks

### DIFF
--- a/dmocks/expectation.d
+++ b/dmocks/expectation.d
@@ -37,10 +37,10 @@ class CallExpectation : Expectation
 
     Action action;
 
-    override string toString(string intendation)
+    override string toString(string indentation)
     {
         auto apndr = appender!(string);
-        apndr.put(intendation);
+        apndr.put(indentation);
         apndr.put("Expectation: ");
         bool details = !satisfied;
 
@@ -52,10 +52,10 @@ class CallExpectation : Expectation
         apndr.put("Method: " ~ name.toString() ~ " " ~ arguments.toString() ~ " " ~ qualifiers.toString() ~ " ExpectedCalls: " ~ repeatInterval.toString());
         if (details)
         {
-            apndr.put("\n" ~ intendation ~ "Calls: " ~ _matchedCalls.length.to!string);
+            apndr.put("\n" ~ indentation ~ "Calls: " ~ _matchedCalls.length.to!string);
             foreach(Call call; _matchedCalls)
             {
-                apndr.put("\n" ~ intendation ~ "  " ~ call.toString());
+                apndr.put("\n" ~ indentation ~ "  " ~ call.toString());
             }
         }
         return apndr.data;
@@ -146,10 +146,10 @@ class GroupExpectation : Expectation
         return true;
     }
 
-    override string toString(string intendation)
+    override string toString(string indentation)
     {
         auto apndr = appender!(string);
-        apndr.put(intendation);
+        apndr.put(indentation);
         apndr.put("GroupExpectation: ");
         bool details = !satisfied;
 
@@ -171,7 +171,7 @@ class GroupExpectation : Expectation
             foreach(Expectation expectation; expectations)
             {
                 apndr.put("\n");
-                apndr.put(expectation.toString(intendation ~ "  "));
+                apndr.put(expectation.toString(indentation ~ "  "));
             }
         }
         return apndr.data;
@@ -195,7 +195,7 @@ interface Expectation
 {
     CallExpectation match(Call call);
     bool satisfied();
-    string toString(string intendation);
+    string toString(string indentation);
     string toString();
 }
 

--- a/dmocks/expectation.d
+++ b/dmocks/expectation.d
@@ -49,13 +49,13 @@ class CallExpectation : Expectation
         else
             apndr.put("not satisfied, ");
 
-        apndr.put("Method: " ~ name.toString() ~ " " ~ arguments.toString() ~" "~ qualifiers.toString() ~ " ExpectedCalls: " ~ repeatInterval.toString());
+        apndr.put("Method: " ~ name.toString() ~ " " ~ arguments.toString() ~ " " ~ qualifiers.toString() ~ " ExpectedCalls: " ~ repeatInterval.toString());
         if (details)
         {
             apndr.put("\n" ~ intendation ~ "Calls: " ~ _matchedCalls.length.to!string);
             foreach(Call call; _matchedCalls)
             {
-                apndr.put(intendation ~"  "~call.toString());
+                apndr.put("\n" ~ intendation ~ "  " ~ call.toString());
             }
         }
         return apndr.data;
@@ -165,12 +165,12 @@ class GroupExpectation : Expectation
 
         apndr.put("Interval: ");
         apndr.put(repeatInterval.toString());
-        apndr.put("\n");
 
         if (details)
         {
             foreach(Expectation expectation; expectations)
             {
+                apndr.put("\n");
                 apndr.put(expectation.toString(intendation ~ "  "));
             }
         }


### PR DESCRIPTION
when expectations are not satisfied, the error message is hard to read as it contains indentation without corresponding line breaks:

```
GroupExpectation: not satisfied, unordered, Interval: 1
  GroupExpectation: not satisfied, unordered, Interval: 1
    Expectation: satisfied, Method: Bar.doSomeCalculations (ubyte[] []) @system ExpectedCalls: 1    Expectation: not satisfied, Method: Bar.doSomeCalculations (ubyte[] []) @system ExpectedCalls: 1
    Calls: 0    Expectation: not satisfied, Method: Bar.doSomeCalculations (ubyte[] []) @system ExpectedCalls: 1
    Calls: 0
```
